### PR TITLE
Flatten slices before processing

### DIFF
--- a/src/main/kotlin/simplecolocalization/SimpleColocalization.kt
+++ b/src/main/kotlin/simplecolocalization/SimpleColocalization.kt
@@ -148,13 +148,15 @@ class SimpleColocalization : Command {
 
     /** Runs after the parameters above are populated. */
     override fun run() {
-        val image = WindowManager.getCurrentImage()
+        var image = WindowManager.getCurrentImage()
         if (image != null) {
-            // Flatten slices of the image. This step should probably be done during the preprocessing step - however
-            // this operation is not done in-place but creates a new image, which makes this hard.
-            val flatImage = ZProjector.run(image, "max")
+            if (image.nSlices > 1) {
+                // Flatten slices of the image. This step should probably be done during the preprocessing step - however
+                // this operation is not done in-place but creates a new image, which makes this hard.
+                image = ZProjector.run(image, "max")
+            }
 
-            process(flatImage)
+            process(image)
         } else {
             MessageDialog(IJ.getInstance(), "Error", "There is no file open")
         }

--- a/src/main/kotlin/simplecolocalization/SimpleColocalization.kt
+++ b/src/main/kotlin/simplecolocalization/SimpleColocalization.kt
@@ -7,8 +7,8 @@ import ij.gui.MessageDialog
 import ij.gui.Roi
 import ij.measure.Measurements
 import ij.measure.ResultsTable
-import ij.plugin.ZProjector
 import ij.plugin.ChannelSplitter
+import ij.plugin.ZProjector
 import ij.plugin.filter.BackgroundSubtracter
 import ij.plugin.filter.EDM
 import ij.plugin.filter.MaximumFinder

--- a/src/main/kotlin/simplecolocalization/SimpleColocalization.kt
+++ b/src/main/kotlin/simplecolocalization/SimpleColocalization.kt
@@ -14,6 +14,8 @@ import ij.plugin.filter.ParticleAnalyzer
 import ij.plugin.filter.RankFilters
 import ij.plugin.frame.RoiManager
 import ij.process.ImageConverter
+import java.io.File
+import net.imagej.Dataset
 import net.imagej.ImageJ
 import org.scijava.ItemVisibility
 import org.scijava.command.Command
@@ -202,7 +204,12 @@ class SimpleColocalization : Command {
         @JvmStatic
         fun main(args: Array<String>) {
             val ij = ImageJ()
-            ij.ui().showUI()
+            ij.launch()
+
+            val file: File = ij.ui().chooseFile(null, "open")
+            val dataset: Dataset = ij.scifio().datasetIO().open(file.path)
+
+            ij.ui().show(dataset)
             ij.command().run(SimpleColocalization::class.java, true)
         }
     }

--- a/src/main/kotlin/simplecolocalization/SimpleColocalization.kt
+++ b/src/main/kotlin/simplecolocalization/SimpleColocalization.kt
@@ -7,6 +7,7 @@ import ij.gui.MessageDialog
 import ij.gui.Roi
 import ij.measure.Measurements
 import ij.measure.ResultsTable
+import ij.plugin.ZProjector
 import ij.plugin.filter.BackgroundSubtracter
 import ij.plugin.filter.EDM
 import ij.plugin.filter.MaximumFinder
@@ -149,7 +150,11 @@ class SimpleColocalization : Command {
     override fun run() {
         val image = WindowManager.getCurrentImage()
         if (image != null) {
-            process(image)
+            // Flatten slices of the image. This step should probably be done during the preprocessing step - however
+            // this operation is not done in-place but creates a new image, which makes this hard.
+            val flatImage = ZProjector.run(image, "max")
+
+            process(flatImage)
         } else {
             MessageDialog(IJ.getInstance(), "Error", "There is no file open")
         }


### PR DESCRIPTION
This PR flattens multi-slice images before processing.

Documentation for the ZProjector can be found at https://imagej.nih.gov/ij/developer/api/ij/plugin/ZProjector.html.

Closes #27 and closes #18.